### PR TITLE
Add documentation comments to Rust source files

### DIFF
--- a/shared-kernel/src/lib.rs
+++ b/shared-kernel/src/lib.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use uuid::Uuid;
 
+/// A unique identifier for an entity of type `T`.
 #[derive(Debug)]
 pub struct Id<T> {
     pub id: Uuid,
@@ -46,6 +47,7 @@ impl<T> Clone for Id<T> {
 }
 
 impl<T> Id<T> {
+    /// Creates a new unique identifier.
     pub fn new() -> Self {
         Self {
             id: Uuid::new_v4(),
@@ -54,6 +56,7 @@ impl<T> Id<T> {
     }
 }
 
+/// An entity with a unique identifier and associated data.
 #[derive(Debug)]
 pub struct Entity<T> {
     pub id: Id<T>,

--- a/shared-kernel/src/lib.rs
+++ b/shared-kernel/src/lib.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use uuid::Uuid;
 
-/// A unique identifier for an entity of type `T`.
+/// A unique identifier for a data value object of type `T`.
 #[derive(Debug)]
 pub struct Id<T> {
     pub id: Uuid,
@@ -56,7 +56,7 @@ impl<T> Id<T> {
     }
 }
 
-/// An entity with a unique identifier and associated data.
+/// An entity with a unique identifier and associated data value object.
 #[derive(Debug)]
 pub struct Entity<T> {
     pub id: Id<T>,

--- a/task/src/domain/error.rs
+++ b/task/src/domain/error.rs
@@ -6,14 +6,18 @@ use super::{
     task::Task,
 };
 
+/// Represents errors that can occur in the task domain.
 #[derive(Debug, Error)]
 pub enum TaskDomainError {
+    /// Error indicating that a status was not found in a net.
     #[error("status {status:?} not found in net {net:?}")]
     StatusNotFoundInNet { net: Id<Net>, status: Id<Status> },
 
+    /// Error indicating that a task was not found in a net.
     #[error("task {task:?} not found in net {net:?}")]
     TaskNotFoundInNet { net: Id<Net>, task: Id<Task> },
 
+    /// Error indicating that a relation was not found in a net.
     #[error("relation from {from:?} to {to:?} not found in net {net:?}")]
     RelationNotFoundInNet {
         net: Id<Net>,
@@ -21,15 +25,19 @@ pub enum TaskDomainError {
         to: Id<Task>,
     },
 
+    /// Error indicating that relation constraints were not satisfied for a task in a net.
     #[error("relation constraints not satisfied for task {task:?} in net {net:?}")]
     RelationConstraintNotSatisfied { net: Id<Net>, task: Id<Task> },
 
+    /// Error indicating that a task is already in a net.
     #[error("task {task:?} already in net {net:?}")]
     TaskAlreadyInNet { task: Id<Task>, net: Id<Net> },
 
+    /// Error indicating that a status is the default status in a net and cannot be removed.
     #[error("status {status:?} is default status in net {net:?}")]
     StatusNotRemovable { net: Id<Net>, status: Id<Status> },
 
+    /// Error indicating that a cycle was found in a net, which is not allowed.
     #[error("cycle found in net {0:?}")]
     CycleNotAllowedInNet(Id<Net>),
 }

--- a/task/src/domain/list.rs
+++ b/task/src/domain/list.rs
@@ -1,12 +1,17 @@
 use shared_kernel::{Entity, Id};
 
+/// Represents a list with a title.
 #[derive(Debug)]
 pub struct List {
     title: String,
 }
 
+/// Trait for aggregate root operations on a `List`.
 pub trait ListAggregateRoot {
+    /// Renames the list with a new title.
     fn rename(&mut self, title: String);
+
+    /// Creates a new list with the given title.
     fn new(title: String) -> Self;
 }
 

--- a/task/src/domain/list.rs
+++ b/task/src/domain/list.rs
@@ -1,6 +1,6 @@
 use shared_kernel::{Entity, Id};
 
-/// Represents a list with a title.
+/// Represents a task list.
 #[derive(Debug)]
 pub struct List {
     title: String,

--- a/task/src/domain/net.rs
+++ b/task/src/domain/net.rs
@@ -26,7 +26,7 @@ pub enum RelationType {
     Require,
 }
 
-/// Represents the schema of a network, including statuses and default/accepted statuses.
+/// Represents the status schema of a network, including statuses and default/accepted statuses.
 #[derive(Debug)]
 pub struct Schema {
     status: Vec<Entity<Status>>,
@@ -100,7 +100,7 @@ fn propagate_at(net: &mut Entity<Net>, task: &Id<Task>) -> TaskDomainResult<()> 
     })
 }
 
-/// Propagates changes through tasks in the network using a custom task transformation function.
+/// Propagates changes through tasks in the network using a transformation function applied to toposorted task list.
 fn propagate<F>(net: &mut Entity<Net>, sorted_tasks_transform: F) -> TaskDomainResult<()>
 where
     F: Fn(Vec<Id<Task>>) -> Vec<Id<Task>>,

--- a/task/src/domain/net.rs
+++ b/task/src/domain/net.rs
@@ -9,6 +9,7 @@ use shared_kernel::{Entity, Id};
 
 use super::{error::TaskDomainError, task::Task};
 
+/// Represents a network of tasks and their relations.
 #[derive(Debug)]
 pub struct Net {
     relations: DiGraphMap<Id<Task>, RelationType>,
@@ -16,12 +17,16 @@ pub struct Net {
     tasks: HashMap<Id<Task>, Id<Status>>,
 }
 
+/// Represents the type of relation between tasks.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RelationType {
+    /// A composition relation.
     Compose,
+    /// A requirement relation.
     Require,
 }
 
+/// Represents the schema of a network, including statuses and default/accepted statuses.
 #[derive(Debug)]
 pub struct Schema {
     status: Vec<Entity<Status>>,
@@ -29,6 +34,7 @@ pub struct Schema {
     accepted: Id<Status>,
 }
 
+/// Represents the status of a task.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Status {
     name: String,
@@ -36,24 +42,34 @@ pub struct Status {
 
 type TaskDomainResult<T> = Result<T, TaskDomainError>;
 
+/// Trait for aggregate root operations on a `Net`.
 pub trait NetAggregateRoot {
+    /// Adds a new status to the network.
     fn new_status(&mut self, status_name: String);
+    /// Removes a status from the network.
     fn remove_status(&mut self, status_id: Id<Status>) -> TaskDomainResult<()>;
+    /// Changes the name of a status in the network.
     fn change_status_name(
         &mut self,
         status_id: Id<Status>,
         new_name: String,
     ) -> TaskDomainResult<()>;
+    /// Changes the default status of the network.
     fn change_default(&mut self, new_default: Id<Status>) -> TaskDomainResult<()>;
+    /// Adds a new task to the network.
     fn add_task(&mut self, task_id: Id<Task>) -> TaskDomainResult<()>;
+    /// Removes a task from the network.
     fn remove_task(&mut self, task_id: Id<Task>) -> TaskDomainResult<()>;
+    /// Adds a new relation between tasks in the network.
     fn new_relation(
         &mut self,
         from: Id<Task>,
         to: Id<Task>,
         relation_type: RelationType,
     ) -> TaskDomainResult<()>;
+    /// Removes a relation between tasks in the network.
     fn remove_relation(&mut self, from: Id<Task>, to: Id<Task>) -> TaskDomainResult<()>;
+    /// Changes the status of a task in the network.
     fn change_task_status(
         &mut self,
         task_id: Id<Task>,
@@ -61,10 +77,12 @@ pub trait NetAggregateRoot {
     ) -> TaskDomainResult<()>;
 }
 
+/// Propagates changes through all tasks in the network.
 fn propagate_all(net: &mut Entity<Net>) -> TaskDomainResult<()> {
     propagate(net, |tasks| tasks)
 }
 
+/// Propagates changes from a specific task in the network.
 fn propagate_from(net: &mut Entity<Net>, task: &Id<Task>) -> TaskDomainResult<()> {
     propagate(net, |tasks| {
         tasks
@@ -75,12 +93,14 @@ fn propagate_from(net: &mut Entity<Net>, task: &Id<Task>) -> TaskDomainResult<()
     })
 }
 
+/// Propagates changes at a specific task in the network.
 fn propagate_at(net: &mut Entity<Net>, task: &Id<Task>) -> TaskDomainResult<()> {
     propagate(net, |tasks| {
         tasks.into_iter().skip_while(|t| *t != *task).collect()
     })
 }
 
+/// Propagates changes through tasks in the network using a custom task transformation function.
 fn propagate<F>(net: &mut Entity<Net>, sorted_tasks_transform: F) -> TaskDomainResult<()>
 where
     F: Fn(Vec<Id<Task>>) -> Vec<Id<Task>>,
@@ -112,6 +132,7 @@ where
     Ok(())
 }
 
+/// Checks if a controlled task is accepted in the network.
 fn is_controlled_task_accepted(
     net: &Entity<Net>,
     task: &Id<Task>,

--- a/task/src/domain/task.rs
+++ b/task/src/domain/task.rs
@@ -2,15 +2,22 @@ use shared_kernel::{Entity, Id};
 
 use super::list::List;
 
+/// Represents a task with a name and associated list.
 #[derive(Debug)]
 pub struct Task {
     pub name: String,
     pub list: Id<List>,
 }
 
+/// Trait for aggregate root operations on a `Task`.
 pub trait TaskAggregateRoot {
+    /// Renames the task with a new name.
     fn rename(&mut self, name: String);
+
+    /// Creates a new task with the given name and list.
     fn new(name: String, list: Id<List>) -> Self;
+
+    /// Categorizes the task to a new list.
     fn categorize_to(&mut self, list: Id<List>);
 }
 

--- a/task/src/domain/task.rs
+++ b/task/src/domain/task.rs
@@ -2,7 +2,7 @@ use shared_kernel::{Entity, Id};
 
 use super::list::List;
 
-/// Represents a task with a name and associated list.
+/// Represents a task.
 #[derive(Debug)]
 pub struct Task {
     pub name: String,

--- a/task/src/lib.rs
+++ b/task/src/lib.rs
@@ -1,1 +1,2 @@
+/// The `domain` module contains the core domain logic for the task management system.
 mod domain;


### PR DESCRIPTION
Add documentation comments to Rust source files in the `shared-kernel` and `task` directories.

* **shared-kernel/src/lib.rs**
  - Add documentation comments for the `Id` struct and its methods.
  - Add documentation comments for the `Entity` struct and its methods.

* **task/src/domain/error.rs**
  - Add documentation comments for the `TaskDomainError` enum and its variants.

* **task/src/domain/list.rs**
  - Add documentation comments for the `List` struct.
  - Add documentation comments for the `ListAggregateRoot` trait and its methods.

* **task/src/domain/net.rs**
  - Add documentation comments for the `Net` struct and its methods.
  - Add documentation comments for the `RelationType` enum.
  - Add documentation comments for the `Schema` struct.
  - Add documentation comments for the `Status` struct.
  - Add documentation comments for the `NetAggregateRoot` trait and its methods.
  - Add documentation comments for the `propagate`, `propagate_all`, `propagate_from`, `propagate_at`, and `is_controlled_task_accepted` functions.

* **task/src/domain/task.rs**
  - Add documentation comments for the `Task` struct.
  - Add documentation comments for the `TaskAggregateRoot` trait and its methods.

* **task/src/lib.rs**
  - Add documentation comments for the `domain` module.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dawnchan030920/just-dev/pull/1?shareId=aef27b1e-f469-4744-b84f-78731680cfee).